### PR TITLE
fix: disable showing mobile-hider when using `embedded` variant

### DIFF
--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -388,14 +388,6 @@ export class RampInstantSDK {
     this._config.containerNode?.appendChild(this.domNodes.shadowHost);
 
     this._isVisible = true;
-
-    const widgetMode = determineWidgetVariant(this._config);
-
-    const containerWidth = this._config.containerNode?.getBoundingClientRect()?.width ?? undefined;
-
-    if (widgetMode !== 'desktop' && widgetMode !== 'embedded-desktop') {
-      hideWebsiteBelow(this.domNodes.shadow, containerWidth);
-    }
   }
 
   private _showUsingOverlayMode(): void {


### PR DESCRIPTION
I used [ramp-instant-demo-app](https://github.com/RampNetwork/ramp-instant-demo-app) for presentation. 
Using `embedded` variant

## Issue:
The "white box" at the bottom is stuck to the bottom of the browser.

https://user-images.githubusercontent.com/14345256/123428261-e7d98d00-d5c5-11eb-955a-e21f641b3803.mp4

## Fixed:

### Desktop:

https://user-images.githubusercontent.com/14345256/123428284-ed36d780-d5c5-11eb-902f-74ba5ad77099.mp4

### Mobile:

https://user-images.githubusercontent.com/14345256/123428535-338c3680-d5c6-11eb-94c0-3046a235fa7d.MOV