### PR TITLE
Improve/lint types

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,11 @@
 export const baseWidgetUrl = 'https://buy.ramp.network/';
+
 export const purchasePollingDelay = 1000;
+
 export const randomIntMultiplier = 10000000;
+
+export const widgetDesktopWidth = 895;
+export const widgetDesktopHeight = 590;
+
+export const minWidgetMobileWidth = 320;
+export const minWidgetMobileHeight = 667;

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,1 +1,3 @@
 export const baseWidgetUrl = 'https://buy.ramp.network/';
+export const purchasePollingDelay = 1000;
+export const randomIntMultiplier = 10000000;

--- a/src/event-polling.ts
+++ b/src/event-polling.ts
@@ -27,7 +27,3 @@ export async function doFetchPurchase(
     return null;
   }
 }
-
-export async function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/src/init-helpers.ts
+++ b/src/init-helpers.ts
@@ -4,7 +4,6 @@ import {
   IHostConfigWithWidgetInstanceId,
   InternalEventTypes,
   TAllEvents,
-  WidgetVariantTypes,
 } from './types';
 import {
   minWidgetMobileHeight,

--- a/src/init-helpers.ts
+++ b/src/init-helpers.ts
@@ -10,7 +10,7 @@ import {
   minWidgetMobileWidth,
   widgetDesktopHeight,
   widgetDesktopWidth,
-} from './utils';
+} from './consts';
 
 export function initWidgetIframeUrl(config: IHostConfigWithWidgetInstanceId): string {
   const baseUrl = new URL(config.url || baseWidgetUrl);

--- a/src/init-helpers.ts
+++ b/src/init-helpers.ts
@@ -1,16 +1,16 @@
 import { baseWidgetUrl } from './consts';
 import {
-  AllWidgetVariants,
-  IHostConfigWithWidgetInstanceId,
-  InternalEventTypes,
-  TAllEvents,
-} from './types';
-import {
   minWidgetMobileHeight,
   minWidgetMobileWidth,
   widgetDesktopHeight,
   widgetDesktopWidth,
 } from './consts';
+import {
+  AllWidgetVariants,
+  IHostConfigWithWidgetInstanceId,
+  InternalEventTypes,
+  TAllEvents,
+} from './types';
 
 export function initWidgetIframeUrl(config: IHostConfigWithWidgetInstanceId): string {
   const baseUrl = new URL(config.url || baseWidgetUrl);

--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -167,7 +167,7 @@ export class RampInstantSDK {
       this._listeners[type].push({ callback, internal });
     }
 
-    this._runPostSubscribeHooks(type, internal);
+    this._runPostSubscribeHooks(type);
   }
 
   private _subscribeToWidgetEvents(event: MessageEvent): void {
@@ -356,10 +356,7 @@ export class RampInstantSDK {
     this._isPollingForSwapStatus = false;
   }
 
-  private _runPostSubscribeHooks(
-    eventType: TAllEventTypes | '*',
-    isHandlerInternal: boolean
-  ): void {
+  private _runPostSubscribeHooks(eventType: TAllEventTypes | '*'): void {
     /*
      *  Handles a case where a host subscribes to these events after
      *  the `PURCHASE_CREATED` event is fired

--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -1,5 +1,5 @@
 import bodyScrollLock from 'body-scroll-lock';
-import { baseWidgetUrl } from './consts';
+import { baseWidgetUrl, purchasePollingDelay } from './consts';
 import { delay, doFetchPurchase } from './event-polling';
 import { hideWebsiteBelow } from './init-helpers';
 
@@ -323,8 +323,7 @@ export class RampInstantSDK {
       countListenersForEvent(this._listeners, WidgetEventTypes.PURCHASE_SUCCESSFUL) > 0 ||
       countListenersForEvent(this._listeners, WidgetEventTypes.PURCHASE_FAILED) > 0
     ) {
-      // tslint:disable-next-line:no-magic-numbers
-      await delay(1000);
+      await delay(purchasePollingDelay);
 
       const purchase = await doFetchPurchase(apiUrl, purchaseExternalId, token);
 

--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -123,7 +123,7 @@ export class RampInstantSDK {
 
   public on<T extends TAllEvents>(
     type: T['type'] | '*',
-    callback: (event: T) => any
+    callback: (event: T) => void
   ): RampInstantSDK {
     this._on(type, callback, false);
 
@@ -132,7 +132,7 @@ export class RampInstantSDK {
 
   public unsubscribe(
     type: TAllEvents['type'] | '*',
-    callback: (event: TAllEvents) => any
+    callback: (event: TAllEvents) => void
   ): RampInstantSDK {
     if (type === '*') {
       const allTypes = Object.entries(this._listeners);
@@ -150,7 +150,7 @@ export class RampInstantSDK {
 
   public _on<T extends TAllEvents>(
     type: T['type'] | '*',
-    callback: (event: T) => any,
+    callback: (event: T) => void,
     internal: boolean
   ): void {
     if (type !== '*' && !this._listeners[type]) {

--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -1,6 +1,6 @@
 import bodyScrollLock from 'body-scroll-lock';
 import { baseWidgetUrl, purchasePollingDelay } from './consts';
-import { delay, doFetchPurchase } from './event-polling';
+import { doFetchPurchase } from './event-polling';
 import { hideWebsiteBelow } from './init-helpers';
 
 import {
@@ -28,6 +28,7 @@ import {
 
 import {
   countListenersForEvent,
+  delay,
   determineWidgetVariant,
   getRandomIntString,
   initEventListenersDict,

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export interface IConfigError {
 
 export interface IWidgetEvent {
   type: string;
-  payload: any | null;
+  payload: unknown;
   internal?: boolean;
 }
 
@@ -229,5 +229,5 @@ export type TEventListenerDict = {
 
 export interface IEventListener {
   internal: boolean;
-  callback(evt: TAllEvents): any;
+  callback(evt: TAllEvents): void;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,6 @@ import {
   TAllEventTypes,
   TEventListenerDict,
   WidgetEventTypes,
-  WidgetVariantTypes,
 } from './types';
 
 export function getRandomIntString(): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { randomIntMultiplier } from './consts';
 import {
   AllWidgetVariants,
   EventSeverity,
@@ -16,8 +17,7 @@ export function getRandomIntString(): string {
     return String(crypto.getRandomValues(new Uint32Array(1))[0]);
   } catch {
     // if `crypto` is not supported, fall back to Math.random
-    // tslint:disable-next-line:no-magic-numbers
-    return String(Math.floor(Math.random() * 10000000));
+    return String(Math.floor(Math.random() * randomIntMultiplier));
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,10 @@
-import { randomIntMultiplier } from './consts';
+import {
+  minWidgetMobileHeight,
+  minWidgetMobileWidth,
+  randomIntMultiplier,
+  widgetDesktopHeight,
+  widgetDesktopWidth,
+} from './consts';
 import {
   AllWidgetVariants,
   EventSeverity,
@@ -19,12 +25,6 @@ export function getRandomIntString(): string {
     return String(Math.floor(Math.random() * randomIntMultiplier));
   }
 }
-
-export const widgetDesktopWidth = 895;
-export const widgetDesktopHeight = 590;
-
-export const minWidgetMobileWidth = 320;
-export const minWidgetMobileHeight = 667;
 
 export function normalizeConfigAndLogErrorsOnInvalidFields(
   config: Partial<IHostConfig>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -192,3 +192,7 @@ export function concatRelativePath(base: string | URL, path: string): URL {
 export function urlWithoutTrailingSlash(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 }
+
+export async function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -189,7 +189,7 @@ export function concatRelativePath(base: string | URL, path: string): URL {
   return new URL(`${normalizedBase}/${normalizedPath}`);
 }
 
-export function urlWithoutTrailingSlash(url: string): string {
+function urlWithoutTrailingSlash(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,7 +99,7 @@ export function initEventListenersDict(): TEventListenerDict {
 
       return listenersDict;
     },
-    {} as any
+    {} as TEventListenerDict
   ) as TEventListenerDict;
 }
 
@@ -136,7 +136,7 @@ export function determineWidgetVariant(config: IHostConfig): AllWidgetVariants {
 }
 
 export function isHtmlElement(element: Element): element is HTMLElement {
-  return typeof (element as any).blur === 'function';
+  return typeof (element as HTMLElement).blur === 'function';
 }
 
 function validateContainerNode(

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,12 +2,12 @@ import { concatRelativePath } from '../src/utils';
 
 describe('Utils', () => {
   describe('concatRelativePath', () => {
-    it('No slashes', () =>
+    it('Without leading and trailing slash', () =>
       expect(concatRelativePath('https://buy.ramp.network', 'api/swap').href).toBe(
         'https://buy.ramp.network/api/swap'
       ));
 
-    it('Both slashes', () =>
+    it('With leading and trailing slash', () =>
       expect(concatRelativePath('https://buy.ramp.network/api/', '/swap').href).toBe(
         'https://buy.ramp.network/api/swap'
       ));

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,15 @@
+import { concatRelativePath } from '../src/utils';
+
+describe('Utils', () => {
+  describe('concatRelativePath', () => {
+    it('No slashes', () =>
+      expect(concatRelativePath('https://buy.ramp.network', 'api/swap').href).toBe(
+        'https://buy.ramp.network/api/swap'
+      ));
+
+    it('Both slashes', () =>
+      expect(concatRelativePath('https://buy.ramp.network/api/', '/swap').href).toBe(
+        'https://buy.ramp.network/api/swap'
+      ));
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "sourceMap": true,
     "declaration": true,
     "allowSyntheticDefaultImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "declarationDir": "dist/types",

--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,6 @@
     "no-return-await": true,
     "no-console": true,
     "no-magic-numbers": true,
-    "no-unused-variable": true,
     "promise-function-async": true,
     "no-invalid-this": [true, "check-function-in-method"],
     "one-variable-per-declaration": true,

--- a/tslint.json
+++ b/tslint.json
@@ -13,6 +13,7 @@
     "no-return-await": true,
     "no-console": true,
     "no-magic-numbers": true,
+    "no-unused-variable": true,
     "promise-function-async": true,
     "no-invalid-this": [true, "check-function-in-method"],
     "one-variable-per-declaration": true,

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "jsRules": {},
   "rules": {
+    "no-any": true,
     "jsx-no-lambda": false,
     "ban-types": false,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
Several improvements:
- Make linter more strict with: `no-any` and fix existing anys
- Make TS more strict with `noUnusedLocals` and `noUnusedParameters` and fix existing unused elems
- Move constants and magic numbers to `consts.ts`
- Add tests for util `concatRelativePath`
- Move delay to utils