### PR TITLE
Improve linter and types

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,1 +1,9 @@
 export const baseWidgetUrl = 'https://buy.ramp.network/';
+
+export const randomIntMultiplier = 10000000;
+
+export const widgetDesktopWidth = 895;
+export const widgetDesktopHeight = 590;
+
+export const minWidgetMobileWidth = 320;
+export const minWidgetMobileHeight = 667;

--- a/src/init-helpers.ts
+++ b/src/init-helpers.ts
@@ -1,16 +1,16 @@
-import { baseWidgetUrl } from './consts';
+import {
+  baseWidgetUrl,
+  minWidgetMobileHeight,
+  minWidgetMobileWidth,
+  widgetDesktopHeight,
+  widgetDesktopWidth,
+} from './consts';
 import {
   AllWidgetVariants,
   IHostConfigWithWidgetInstanceId,
   InternalEventTypes,
   TAllEvents,
 } from './types';
-import {
-  minWidgetMobileHeight,
-  minWidgetMobileWidth,
-  widgetDesktopHeight,
-  widgetDesktopWidth,
-} from './utils';
 
 export function getBaseUrl(config: IHostConfigWithWidgetInstanceId): URL {
   return new URL(config.url || baseWidgetUrl);

--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -118,7 +118,7 @@ export class RampInstantSDK {
 
   public on<T extends TAllEvents>(
     type: T['type'] | '*',
-    callback: (event: T) => any
+    callback: (event: T) => void
   ): RampInstantSDK {
     this._on(type, callback, false);
 
@@ -127,7 +127,7 @@ export class RampInstantSDK {
 
   public unsubscribe(
     type: TAllEvents['type'] | '*',
-    callback: (event: TAllEvents) => any
+    callback: (event: TAllEvents) => void
   ): RampInstantSDK {
     if (type === '*') {
       const allTypes = Object.entries(this._listeners);
@@ -145,7 +145,7 @@ export class RampInstantSDK {
 
   public _on<T extends TAllEvents>(
     type: T['type'] | '*',
-    callback: (event: T) => any,
+    callback: (event: T) => void,
     internal: boolean
   ): void {
     if (type !== '*' && !this._listeners[type]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,6 @@ type TFiatValue = string;
 type TAddress = string;
 type TEmailAddress = string;
 type TCryptoAmount = string;
-type TPoolFee = number;
-type TRampFee = number;
 type TAssetExchangeRate = number;
 type TFinalTxHash = string;
 type TActionID = string;
@@ -122,7 +120,7 @@ export interface IConfigError {
 
 export interface IWidgetEvent {
   type: string;
-  payload: any | null;
+  payload: unknown;
   internal?: boolean;
 }
 
@@ -270,7 +268,7 @@ export type TEventListenerDict = {
 
 export interface IEventListener {
   internal: boolean;
-  callback(evt: TAllEvents): any;
+  callback(evt: TAllEvents): void;
 }
 
 export interface IOnRequestCryptoAccountResult {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,11 @@
 import {
+  minWidgetMobileHeight,
+  minWidgetMobileWidth,
+  randomIntMultiplier,
+  widgetDesktopHeight,
+  widgetDesktopWidth,
+} from './consts';
+import {
   AllWidgetVariants,
   EventSeverity,
   IConfigError,
@@ -8,7 +15,6 @@ import {
   TAllEventTypes,
   TEventListenerDict,
   WidgetEventTypes,
-  WidgetVariantTypes,
 } from './types';
 
 export function getRandomIntString(): string {
@@ -17,15 +23,9 @@ export function getRandomIntString(): string {
   } catch {
     // if `crypto` is not supported, fall back to Math.random
     // tslint:disable-next-line:no-magic-numbers
-    return String(Math.floor(Math.random() * 10000000));
+    return String(Math.floor(Math.random() * randomIntMultiplier));
   }
 }
-
-export const widgetDesktopWidth = 895;
-export const widgetDesktopHeight = 590;
-
-export const minWidgetMobileWidth = 320;
-export const minWidgetMobileHeight = 667;
 
 export function normalizeConfigAndLogErrorsOnInvalidFields(
   config: Partial<IHostConfig>
@@ -100,7 +100,7 @@ export function initEventListenersDict(): TEventListenerDict {
 
       return listenersDict;
     },
-    {} as any
+    {} as TEventListenerDict
   ) as TEventListenerDict;
 }
 
@@ -129,7 +129,7 @@ export function determineWidgetVariant(config: IHostConfig): AllWidgetVariants {
 }
 
 export function isHtmlElement(element: Element): element is HTMLElement {
-  return typeof (element as any).blur === 'function';
+  return typeof (element as HTMLElement).blur === 'function';
 }
 
 function validateContainerNode(
@@ -182,6 +182,6 @@ export function concatRelativePath(base: string | URL, path: string): URL {
   return new URL(`${normalizedBase}/${normalizedPath}`);
 }
 
-export function urlWithoutTrailingSlash(url: string): string {
+function urlWithoutTrailingSlash(url: string): string {
   return url.endsWith('/') ? url.slice(0, -1) : url;
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,15 @@
+import { concatRelativePath } from '../src/utils';
+
+describe('Utils', () => {
+  describe('concatRelativePath', () => {
+    it('Without leading and trailing slash', () =>
+      expect(concatRelativePath('https://buy.ramp.network', 'api/swap').href).toBe(
+        'https://buy.ramp.network/api/swap'
+      ));
+
+    it('With leading and trailing slash', () =>
+      expect(concatRelativePath('https://buy.ramp.network/api/', '/swap').href).toBe(
+        'https://buy.ramp.network/api/swap'
+      ));
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,21 +2,19 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es5",
-    "module":"es2015",
+    "module": "es2015",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "strict": true,
     "sourceMap": true,
     "declaration": true,
     "allowSyntheticDefaultImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "declarationDir": "dist/types",
     "outDir": "dist/lib",
-    "typeRoots": [
-      "node_modules/@types"
-    ]
+    "typeRoots": ["node_modules/@types"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
   "jsRules": {},
   "rules": {
+    "no-any": true,
     "jsx-no-lambda": false,
     "ban-types": false,
     "object-literal-sort-keys": false,
@@ -19,12 +20,7 @@
     "no-boolean-literal-compare": true,
     "no-irregular-whitespace": true,
     "trailing-comma": true,
-    "typedef": [
-      true,
-      "call-signature",
-      "property-declaration",
-      "member-variable-declaration"
-    ],
+    "typedef": [true, "call-signature", "property-declaration", "member-variable-declaration"],
     "no-unnecessary-callback-wrapper": true,
     "no-unnecessary-qualifier": true,
     "object-literal-key-quotes": [true, "as-needed"],


### PR DESCRIPTION
Several improvements:

- Make linter more strict with: no-any and fix existing anys
- Make TS more strict with noUnusedLocals and noUnusedParameters and fix existing unused elems
- Move constants and magic numbers to consts.ts
- Add tests for util concatRelativePath