### PR TITLE
feat: use iframe credentialless attr #RCKT-497

### DIFF
--- a/src/init-helpers.ts
+++ b/src/init-helpers.ts
@@ -163,6 +163,7 @@ function prepareIframeNode(
   const iframe = document.createElement('iframe');
 
   iframe.setAttribute('src', url);
+  iframe.setAttribute('credentialless', 'credentialless');
 
   if (containerNode) {
     iframe.setAttribute(


### PR DESCRIPTION
We need to set `credentialless` iframe attribute to break COEP/CORP requiremnt.