### PR TITLE
feat: support new Widget #CRBR-930

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramp-network/ramp-instant-sdk",
-  "version": "4.0.8",
+  "version": "5.0.0",
   "description": "SDK for Ramp Instant",
   "keywords": [],
   "main": "dist/ramp-instant-sdk.umd.js",
@@ -81,5 +81,6 @@
   },
   "dependencies": {
     "body-scroll-lock": "^3.1.5"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "singleQuote": true
   },
   "devDependencies": {
-    "@types/body-scroll-lock": "^3.1.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.12",
     "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,5 @@
   },
   "dependencies": {
     "body-scroll-lock": "^3.1.5"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/body-scroll-lock.ts
+++ b/src/body-scroll-lock.ts
@@ -1,0 +1,96 @@
+// Track if body scroll is locked
+let isLocked = false;
+let originalOverflow: string | null = null;
+let originalPaddingRight: string | null = null;
+let originalPosition: string | null = null;
+let originalTop: string | null = null;
+let originalLeft: string | null = null;
+let originalWidth: string | null = null;
+let originalHeight: string | null = null;
+let scrollPosition: number | null = null;
+
+/**
+ * Check if the device is iOS
+ */
+function isIOS(): boolean {
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+    !(window as Window & { MSStream?: unknown }).MSStream
+  );
+}
+
+/**
+ * Disables body scroll while preserving scroll position
+ */
+export function disableBodyScroll(): void {
+  if (!isLocked) {
+    const body = document.body;
+    const scrollbarWidth = window.innerWidth - body.clientWidth;
+
+    // Store original values
+    originalOverflow = body.style.overflow;
+    originalPaddingRight = body.style.paddingRight;
+    originalPosition = body.style.position;
+    originalTop = body.style.top;
+    originalLeft = body.style.left;
+    originalWidth = body.style.width;
+    originalHeight = body.style.height;
+
+    // Store scroll position
+    scrollPosition = window.scrollY;
+
+    // Prevent body scroll
+    body.style.overflow = 'hidden';
+
+    // Prevent layout shift by adding padding for scrollbar
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+
+    // iOS Safari specific handling
+    if (isIOS()) {
+      body.style.position = 'fixed';
+      body.style.top = `-${scrollPosition}px`;
+      body.style.left = '0';
+      body.style.width = '100%';
+      body.style.height = '100%';
+      body.style.touchAction = 'none';
+    }
+
+    isLocked = true;
+  }
+}
+
+/**
+ * Re-enables body scroll
+ */
+export function clearAllBodyScrollLocks(): void {
+  if (isLocked) {
+    const body = document.body;
+
+    // Restore original values
+    body.style.overflow = originalOverflow || '';
+    body.style.paddingRight = originalPaddingRight || '';
+    body.style.position = originalPosition || '';
+    body.style.top = originalTop || '';
+    body.style.left = originalLeft || '';
+    body.style.width = originalWidth || '';
+    body.style.height = originalHeight || '';
+    body.style.touchAction = '';
+
+    // Restore scroll position for iOS
+    if (isIOS() && scrollPosition !== null) {
+      window.scrollTo(0, scrollPosition);
+    }
+
+    originalOverflow = null;
+    originalPaddingRight = null;
+    originalPosition = null;
+    originalTop = null;
+    originalLeft = null;
+    originalWidth = null;
+    originalHeight = null;
+    scrollPosition = null;
+    isLocked = false;
+  }
+}

--- a/src/init-helpers.ts
+++ b/src/init-helpers.ts
@@ -33,20 +33,6 @@ export function initWidgetIframeUrl(config: IHostConfigWithSdkParams): string {
   return baseUrl.toString();
 }
 
-export function hideWebsiteBelow(
-  parent: Element | ShadowRoot,
-  containerWidth?: number | undefined
-): void {
-  const backgroundWebsiteHider = document.createElement('div');
-  backgroundWebsiteHider.classList.add('background-hider');
-
-  if (containerWidth) {
-    backgroundWebsiteHider.style.maxWidth = `${containerWidth}px`;
-  }
-
-  parent.appendChild(backgroundWebsiteHider);
-}
-
 export function initDOMNodeWithOverlay(
   url: string,
   dispatch: (event: TAllEvents) => void,
@@ -359,23 +345,11 @@ function getStylesForShadowDom(variant: AllWidgetVariants): HTMLStyleElement {
   const isEmbedded = variant === 'embedded-mobile' || variant === 'embedded-desktop';
 
   styles.textContent = `
-
-    .background-hider {
-      content: '';
-      height: 30vh;
-      width: 100vw;
-      position: fixed;
-      bottom: 0;
-      transform: translateY(50%);
-      background-color: #f5f8fb;
-      z-index: 999;
-    }
-
     .overlay {
       position: fixed;
       z-index: 1000;
       width: 100vw;
-      height: ${isMobile ? '100%;' : '100vh;'}
+      height: ${isMobile ? '100%;' : '100vh;'}ž
       top: 0;
       left: 0;
       overflow: hidden;
@@ -558,6 +532,29 @@ function getStylesForShadowDom(variant: AllWidgetVariants): HTMLStyleElement {
       box-shadow: 0px 8px 34px rgba(221, 62, 86, 0.4);
       color: #fff;
       border-color: transparent;
+    }
+
+    @supports (width: 100dvw) {
+      .overlay {
+        width: 100dvw;
+      }
+
+      .iframe.visible {
+        ${
+          !isEmbedded && isMobile
+            ? `
+          width: 100dvw;
+          height: 100%;
+        `
+            : ''
+        }
+      }
+    }
+
+    @supports (height: 100dvh) {
+      .overlay {
+        height: ${isMobile ? '100%;' : '100dvh;'}
+      }
     }
   `;
 

--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -1,5 +1,5 @@
-import { clearAllBodyScrollLocks, disableBodyScroll } from 'body-scroll-lock';
-import { getBaseUrl, hideWebsiteBelow, makeIframeResponsive } from './init-helpers';
+import { clearAllBodyScrollLocks, disableBodyScroll } from './body-scroll-lock';
+import { getBaseUrl, makeIframeResponsive } from './init-helpers';
 import { SDK_VERSION, SEND_CRYPTO_SUPPORTED_VERSION } from './consts';
 
 import {
@@ -446,13 +446,7 @@ export class RampInstantSDK {
 
     this._isVisible = true;
 
-    disableBodyScroll(this.domNodes.iframe);
-
-    const widgetMode = determineWidgetVariant(this._config);
-
-    if (widgetMode !== 'desktop' && widgetMode !== 'embedded-desktop') {
-      hideWebsiteBelow(this.domNodes.shadow);
-    }
+    disableBodyScroll();
   }
 
   private _showUsingHostedMode(): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface IHostConfig {
   useSendCryptoCallback?: boolean;
   paymentMethodType?: PaymentMethodType;
   hideExitButton?: boolean;
+  closeable?: boolean;
 }
 
 export interface IHostConfigWithSdkParams extends Omit<IHostConfig, 'useSendCryptoCallback'> {
@@ -178,6 +179,7 @@ export enum WidgetEventTypes {
 }
 
 export enum InternalEventTypes {
+  APP_VERSION = 'APP_VERSION',
   WIDGET_CLOSE_REQUEST = 'WIDGET_CLOSE_REQUEST',
   WIDGET_CLOSE_REQUEST_CANCELLED = 'WIDGET_CLOSE_REQUEST_CANCELLED',
   WIDGET_CLOSE_REQUEST_CONFIRMED = 'WIDGET_CLOSE_REQUEST_CONFIRMED',
@@ -269,6 +271,15 @@ export interface IWidgetCloseRequestConfirmedEvent extends IWidgetEvent {
   internal: true;
 }
 
+export interface IAppVersionEvent extends IWidgetEvent {
+  type: InternalEventTypes.APP_VERSION;
+  payload: {
+    version: `${number}.${number}`;
+  };
+  widgetInstanceId: string;
+  internal: true;
+}
+
 export type TWidgetEvents =
   | IWidgetCloseEvent
   | IWidgetConfigDoneEvent
@@ -281,7 +292,8 @@ export type TInternalEvents =
   | IWidgetCloseRequestCancelledEvent
   | IWidgetCloseRequestConfirmedEvent
   | IRequestCryptoAccountEvent
-  | ISendCryptoEvent;
+  | ISendCryptoEvent
+  | IAppVersionEvent;
 
 export enum InternalSdkEventTypes {
   REQUEST_CRYPTO_ACCOUNT_RESULT = 'REQUEST_CRYPTO_ACCOUNT_RESULT',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,7 +137,7 @@ export function isHtmlElement(element: Element): element is HTMLElement {
 
 function validateContainerNode(
   containerNode: HTMLElement | undefined,
-  variant: SyntheticWidgetVariants
+  _variant: SyntheticWidgetVariants
 ): void {
   if (!document.body) {
     throw new Error("Couldn't find <body> element.");
@@ -149,26 +149,6 @@ function validateContainerNode(
 
   if (!document.body.contains(containerNode)) {
     throw new Error('Container node must be attached to the document.');
-  }
-
-  const { width, height } = containerNode.getBoundingClientRect();
-
-  if (variant === 'embedded-desktop') {
-    if (width + 1 < widgetDesktopWidth) {
-      throw new Error(`Container node must be at least ${widgetDesktopWidth}px wide.`);
-    }
-
-    if (height + 1 < widgetDesktopHeight) {
-      throw new Error(`Container node must be at least ${widgetDesktopHeight}px tall.`);
-    }
-  } else if (variant === 'embedded-mobile') {
-    if (width + 1 < minWidgetMobileWidth) {
-      throw new Error(`Container node must be at least ${minWidgetMobileWidth}px wide.`);
-    }
-
-    if (height + 1 < minWidgetMobileHeight) {
-      throw new Error(`Container node must be at least ${minWidgetMobileHeight}px tall.`);
-    }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,11 +612,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/body-scroll-lock@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-3.1.0.tgz#435f6abf682bf58640e1c2ee5978320b891970e7"
-  integrity sha512-3owAC4iJub5WPqRhxd8INarF2bWeQq1yQHBgYhN0XLBJMpd5ED10RrJ3aKiAwlTyL5wK7RkBD4SZUQz2AAAMdA==
-
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"


### PR DESCRIPTION
# Description
This PR adds backward-compatible support for new Widget in the Web SDK.

# Key changes
- Introduced `APP_VERSION` event to trigger visual and behavioral adjustments for the new Widget:
   - The iframe now dynamically resizes based on its container or viewport.
   - Minimum width and height restrictions for embedded containers have been removed.
   - Escape key handling is now delegated to the Widget itself instead of the SDK.
   - The Widget is displayed as early as possible (instead of waiting for `WIDGET_CONFIG_DONE`), leveraging the app’s own loading state. The SDK’s spinner remains only until the iframe is fully loaded.
- Overlay background is now consistently black with 50% opacity across all app versions. This avoids flickering due to unknown app version at initial load time.
- Embedded `containerNode` restrictions have been lifted regardless of the app version, for the same reason - the app version isn't known prior to load.
- New `closeable` query parameter added to control the new Widget’s close functionality. If not provided, the value is inferred from the variant.
- Replaced `body-scroll-lock` with custom implementation
- Remove `hideWebsiteBelow()`
- Minor code formatting improvements.

# Refs
https://github.com/RampNetwork/ramp-instant/pull/23635