### PR TITLE
feat: parametrize iframe credentialless attribute #CRBR-1300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Added new config option `credentialless` to control `iframe`'s `credentialless` attribute.
+- Removed unused `body-scroll-lock` dependency.
 
 ### BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## [6.0.0]
+
+### Features
+
+- Added new config option `credentialless` to control `iframe`'s `credentialless` attribute.
+
+### BREAKING CHANGES
+
+- The `credentialless` attribute for the Widget's `iframe` (used in both embedded and overlay integrations) **is now disabled by default**. You can re-enable it by setting the `credentialless` property in the SDK configuration. Please note that enabling `credentialless` prevents storage from being preserved between sessions and may break password managers and social logins.
+
+## [5.0.3]
+
+### Bug Fixes
+
+- Fixed broken `top` CSS property for overlay.
+
+## [5.0.0]
+
+### Features
+
+- Introduced `APP_VERSION` event to trigger visual and behavioral adjustments for the new Widget:
+  - The iframe now dynamically resizes based on its container or viewport.
+  - Minimum width and height restrictions for embedded containers have been removed.
+  - Escape key handling is now delegated to the Widget itself instead of the SDK.
+  - The Widget is displayed as early as possible (instead of waiting for `WIDGET_CONFIG_DONE`), leveraging the app’s own loading state. The SDK’s spinner remains only until the iframe is fully loaded.
+- Overlay background is now consistently black with 50% opacity across all app versions. This avoids flickering due to unknown app version at initial load time.
+- Embedded `containerNode` restrictions have been lifted regardless of the app version, for the same reason - the app version isn't known prior to load.
+- New `closeable` query parameter added to control the new Widget’s close functionality. If not provided, the value is inferred from the variant.
+- Replaced `body-scroll-lock` with custom implementation
+- Removed `hideWebsiteBelow()`.
+- Minor code formatting improvements.
+
 ## [2.0.0]
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramp-network/ramp-instant-sdk",
-  "version": "5.0.3",
+  "version": "6.0.0",
   "description": "SDK for Ramp Instant",
   "keywords": [],
   "main": "dist/ramp-instant-sdk.umd.js",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,5 @@
     "tslint-config-standard": "^9.0.0",
     "tslint-react": "^5.0.0",
     "typescript": "4.5.3"
-  },
-  "dependencies": {
-    "body-scroll-lock": "^3.1.5"
   }
 }

--- a/src/init-helpers.ts
+++ b/src/init-helpers.ts
@@ -55,7 +55,7 @@ export function initDOMNodeWithOverlay(
 
   shadow.appendChild(getStylesForShadowDom(config.variant));
 
-  const iframe = prepareIframeNode(url, config.variant);
+  const iframe = prepareIframeNode(url, config.variant, undefined, config.credentialless);
   const overlay = prepareOverlayNode(iframe, dispatch);
 
   overlay.appendChild(iframe);
@@ -147,12 +147,16 @@ export function importFonts(): void {
 function prepareIframeNode(
   url: string,
   variant: AllWidgetVariants,
-  containerNode?: HTMLElement
+  containerNode?: HTMLElement,
+  credentialless?: boolean
 ): HTMLIFrameElement {
   const iframe = document.createElement('iframe');
 
   iframe.setAttribute('src', url);
-  iframe.setAttribute('credentialless', 'credentialless');
+
+  if (credentialless) {
+    iframe.setAttribute('credentialless', 'credentialless');
+  }
 
   if (containerNode) {
     iframe.setAttribute(

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export interface IHostConfig {
   paymentMethodType?: PaymentMethodType;
   hideExitButton?: boolean;
   closeable?: boolean;
+  credentialless?: boolean;
 }
 
 export interface IHostConfigWithSdkParams extends Omit<IHostConfig, 'useSendCryptoCallback'> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,6 +66,10 @@ export function normalizeConfigAndLogErrorsOnInvalidFields(
     delete config.useSendCryptoCallback;
   }
 
+  if (config.credentialless === undefined) {
+    configCopy.credentialless = false;
+  }
+
   logErrors(errors);
 
   return configCopy as IHostConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,11 +900,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-body-scroll-lock@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
-  integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
> [!CAUTION]
> **BREAKING CHANGE**
> * The `credentialless` attribute for the Widget's `iframe` (used in both embedded and overlay integrations) **is now disabled by default**.
> * You can re-enable it by setting the `credentialless` property in the SDK configuration.
> * Please note that enabling `credentialless` prevents storage from being preserved between sessions and may break password managers and social logins.

