### PR TITLE
fix: don't invoke event listeners for unknown event types #CRBR-1336

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [6.0.1]
+
+### Bug Fixes
+
+- Don't invoke event listeners for unknown event types.
+
 ## [6.0.0]
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramp-network/ramp-instant-sdk",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "SDK for Ramp Instant",
   "keywords": [],
   "main": "dist/ramp-instant-sdk.umd.js",

--- a/src/ramp-instant-sdk.ts
+++ b/src/ramp-instant-sdk.ts
@@ -142,7 +142,7 @@ export class RampInstantSDK {
         this._listeners[key as TAllEventTypes] = filteredHandlers;
       });
     } else {
-      this._listeners[type] = this._listeners[type].filter((l) => l.callback !== callback);
+      this._listeners[type] = this._listeners[type]?.filter((l) => l.callback !== callback);
     }
 
     return this;
@@ -164,7 +164,7 @@ export class RampInstantSDK {
       const allTypes = Object.values(this._listeners);
       allTypes.forEach((eventHandlers) => eventHandlers.push({ callback, internal }));
     } else {
-      this._listeners[type].push({ callback, internal });
+      this._listeners[type]?.push({ callback, internal });
     }
   }
 
@@ -237,6 +237,14 @@ export class RampInstantSDK {
     if (
       !eventData.widgetInstanceId ||
       eventData.widgetInstanceId !== this._config.widgetInstanceId
+    ) {
+      return;
+    }
+
+    if (
+      ![...Object.values(WidgetEventTypes), ...Object.values(InternalEventTypes)].includes(
+        eventData.type
+      )
     ) {
       return;
     }
@@ -351,7 +359,7 @@ export class RampInstantSDK {
   private _dispatchEvent(event: TAllEvents): void {
     const { type } = event;
 
-    this._listeners[type].forEach((handler) => handler.callback(event));
+    this._listeners[type]?.forEach((handler) => handler.callback(event));
   }
 
   private _handleEscapeClick(event: KeyboardEvent): void {


### PR DESCRIPTION
The new Widget sends `APP_VERSION` internal event which is not supported in old SDK versions. This fix prevents such situation in the future where there's an unknown event received from the SDK perspective.