### PR TITLE
fix: adjust constructor payload for signed URL configuration #CRBR-1987

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [6.2.0]
+
+### Features
+
+- Updated constructor payload types to support two authentication flows: signed URL-based (requires `url`, optional `hostApiKey`) or regular (requires `hostApiKey`, optional `url`)
+
 ## [6.1.0]
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ramp-network/ramp-instant-sdk",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "SDK for Ramp Instant",
   "keywords": [],
   "main": "dist/ramp-instant-sdk.umd.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,8 @@ export enum PurchaseStatus {
 
 export type TPurchaseExternalId = string;
 
-export interface IHostConfig {
+// Base interface with all optional fields
+interface IHostConfigBase {
   swapAsset?: TAsset;
   offrampAsset?: TAsset;
   swapAmount?: TSwapAmount;
@@ -66,10 +67,8 @@ export interface IHostConfig {
   fiatCurrency?: TFiatCurrency;
   userAddress?: TEthAddress;
   userEmailAddress?: TEmailAddress;
-  hostApiKey?: THostApiKey;
-  hostLogoUrl: THostLogoUrl;
-  hostAppName: THostAppName;
-  url?: TURL;
+  hostLogoUrl?: THostLogoUrl;
+  hostAppName?: THostAppName;
   pathname?: TPathname;
   variant?: AllWidgetVariants;
   webhookStatusUrl?: TWebhookStatusUrl;
@@ -86,6 +85,20 @@ export interface IHostConfig {
   closeable?: boolean;
   credentialless?: boolean;
 }
+
+// for the signed url flow.
+interface IHostConfigSignedUrlBased extends IHostConfigBase {
+  url: TURL;
+  hostApiKey?: THostApiKey;
+}
+
+// when signed url flow is not used, hostApiKey is required, url is optional
+interface IHostConfigTraditional extends IHostConfigBase {
+  url?: TURL;
+  hostApiKey: THostApiKey;
+}
+
+export type IHostConfig = IHostConfigSignedUrlBased | IHostConfigTraditional;
 
 export interface IHostConfigWithSdkParams extends Omit<IHostConfig, 'useSendCryptoCallback'> {
   sdkType: 'WEB';

--- a/test/ramp-instant-sdk.test.ts
+++ b/test/ramp-instant-sdk.test.ts
@@ -1,7 +1,7 @@
 import { RampInstantSDK } from '../src/ramp-instant-sdk';
 
 describe('Initialize test', () => {
-  it("doesn't throw", () => {
+  it("doesn't throw with hostApiKey", () => {
     expect(
       () =>
         new RampInstantSDK({
@@ -9,6 +9,16 @@ describe('Initialize test', () => {
           swapAsset: 'ETH',
           hostAppName: 'Test',
           hostLogoUrl: 'http://localhost:8080/image.png',
+          hostApiKey: 'test_api_key',
+        })
+    ).not.toThrow();
+  });
+
+  it("doesn't throw with url", () => {
+    expect(
+      () =>
+        new RampInstantSDK({
+          url: 'https://example.com/widget',
         })
     ).not.toThrow();
   });


### PR DESCRIPTION
If the URL is signed according to the URL signature procedure, other params should not be provided since they are included in the signed URL. 

This PR adjusts the constructor payload to account for this.